### PR TITLE
feat and debug for SIGTERM, JOIN and protocols

### DIFF
--- a/Client.cpp
+++ b/Client.cpp
@@ -235,6 +235,15 @@ std::string	Client::extractFirstMsg(std::string& recv_buf)
 		first_msg = recv_buf.substr(0, found);
 		recv_buf.erase(0, found + 2);
 	}
+	else
+	{
+		found = recv_buf.find("\n");
+		if (found != std::string::npos)
+		{
+			first_msg = recv_buf.substr(0, found);
+			recv_buf.erase(0, found + 1);
+		}
+	}
 	return (first_msg);
 }
 

--- a/Command.cpp
+++ b/Command.cpp
@@ -128,9 +128,16 @@ void    Command::user(Client* clnt)
 
 void    Command::join(Client* clnt)
 {
+	std::string					param(clnt->getParam());
 	std::vector<std::string>	chann_names(split(clnt->getParam(), ','));
 	Channel*					chann_ptr(NULL);
+	size_t						found_space(0);
 
+	found_space = param.find(' ');
+	if (found_space == std::string::npos)
+		chann_names = split(param, ',');
+	else
+		chann_names = split(param.substr(0, found_space), ',');
 	for (std::size_t i = 0 ; i < chann_names.size() ; ++i)
 	{
 		if (chann_names[i].length() >= 65 || chann_names[i].front() != '#')

--- a/Command.cpp
+++ b/Command.cpp
@@ -133,7 +133,7 @@ void    Command::join(Client* clnt)
 
 	for (std::size_t i = 0 ; i < chann_names.size() ; ++i)
 	{
-		if (chann_names[i].length() >= 65)
+		if (chann_names[i].length() >= 65 || chann_names[i].front() != '#')
 		{
 			clnt->appendToSendBuf(proto_->errBadChanMask(clnt, chann_names[i]));
 			continue;

--- a/main.cpp
+++ b/main.cpp
@@ -36,6 +36,11 @@ static void	set_server_off(int sig)
 		sv->sendErrorClosingLinkProtoToAllClientsWithMsg("SIGINT in server");
 	else if (sig == SIGQUIT)
 		sv->sendErrorClosingLinkProtoToAllClientsWithMsg("SIGQUIT in server");
+	else if (sig == SIGTERM)
+	{
+		sv->sendErrorClosingLinkProtoToAllClientsWithMsg("SIGTERM in server");
+		std::cout << "hena god in SIGTERM\n";
+	}
 	sv->setStatusOff();
 	std::cout << "signum: [" << sig << "]\n";
 }
@@ -44,6 +49,7 @@ static void	set_signal_handler(void)
 {
 	signal(SIGINT, set_server_off);
 	signal(SIGQUIT, set_server_off);
+	signal(SIGTERM, set_server_off);
 	signal(SIGPIPE, SIG_IGN);
 }
 


### PR DESCRIPTION
- [x]  feat: handling SIGTERM
- [x]  debug: nc에서 JOIN의 채널명 맨 앞이 ‘#’이 아닌 경우 에러 처리
- [x]  debug: nc에서 JOIN의 채널명에 공백이 들어갔을 경우 파싱 처리
- [x]  debug: nc에서 프로토콜 메시지들이 개행(’\n’) 만을 기준으로 들어올때 처리